### PR TITLE
lcm and gcd for negative numbers, should obey lattice laws

### DIFF
--- a/lang/modules/dsp_math.x
+++ b/lang/modules/dsp_math.x
@@ -492,8 +492,7 @@ fn ipowf(b Float, e Int) Float {
 fn gcd2(a Int, b Int) Int {
     var u = a abs;
     var v = b abs;
-    var sign;
-    if(a < 0 && b < 0) { sign = -1 } else { sign = 1 }
+    var sign = if(a < 0 && b < 0) { -1 } else { 1 }
     if(u == 0 && v == 0) { return 0 }
     if (u <= 1 || v <= 1) { return sign }
     var running = true;

--- a/lang/modules/dsp_math.x
+++ b/lang/modules/dsp_math.x
@@ -489,10 +489,13 @@ fn ipowf(b Float, e Int) Float {
 -- GCD / LCM
 -- ============================================================
 
-fn gcd(a Int, b Int) Int {
+fn gcd2(a Int, b Int) Int {
     var u = a abs;
     var v = b abs;
-    if (u <= 1 || v <= 1) { return 1; }
+    var sign;
+    if(a < 0 && b < 0) { sign = -1 } else { sign = 1 }
+    if(u == 0 && v == 0) { return 0 }
+    if (u <= 1 || v <= 1) { return 1 * sign }
     var running = true;
     while (running) {
         if (u < v) {
@@ -503,11 +506,11 @@ fn gcd(a Int, b Int) Int {
         u = u % v;
         running = u > 0;
     }
-    v
+    v * sign
 }
 
 fn lcm(a Int, b Int) Int {
-    if (a <= 0 || b <= 0) { return 0; }
+    if (a abs <= 0 || b abs <= 0) { return 0; }
     if (b == 1) { return a; }
     if (a == 1) { return b; }
     a // gcd(a, b) * b

--- a/lang/modules/dsp_math.x
+++ b/lang/modules/dsp_math.x
@@ -495,7 +495,7 @@ fn gcd2(a Int, b Int) Int {
     var sign;
     if(a < 0 && b < 0) { sign = -1 } else { sign = 1 }
     if(u == 0 && v == 0) { return 0 }
-    if (u <= 1 || v <= 1) { return 1 * sign }
+    if (u <= 1 || v <= 1) { return sign }
     var running = true;
     while (running) {
         if (u < v) {

--- a/lang/modules/dsp_math.x
+++ b/lang/modules/dsp_math.x
@@ -489,7 +489,7 @@ fn ipowf(b Float, e Int) Float {
 -- GCD / LCM
 -- ============================================================
 
-fn gcd2(a Int, b Int) Int {
+fn gcd(a Int, b Int) Int {
     var u = a abs;
     var v = b abs;
     var sign = if(a < 0 && b < 0) { -1 } else { 1 }

--- a/lang/tests/functions/lcm-gcd.x
+++ b/lang/tests/functions/lcm-gcd.x
@@ -1,0 +1,41 @@
+-- lcm / gcd
+
+-- Lattice Laws
+fn commutative_lcm(a, b) = lcm(a, b) == lcm(b, a)
+fn commutative_gcd(a, b) = gcd(a, b) == gcd(b, a)
+
+fn associative_lcm(a, b, c) = lcm(a, lcm(b, c)) == lcm(lcm(a, b), c)
+fn associative_gcd(a, b, c) = gcd(a, gcd(b, c)) == gcd(gcd(a, b), c)
+
+fn absorption_lcm(a, b) = a == lcm(a, gcd(a, b))
+fn absorption_gcd(a, b) = a == gcd(a, lcm(a, b))
+
+fn idempotence_lcm(a) = a == lcm(a, a)
+fn idempotence_gcd(a) = a == gcd(a, a)
+
+fn distributive_lcm(a, b, c) =
+    lcm(a, gcd(b, c)) == gcd(lcm(a, b), lcm(a, c))
+fn distributive_gcd(a, b, c) = gcd(a, lcm(b, c)) == lcm(gcd(a, b), gcd(a, c))
+
+fn selfDuality(a, b, c) =
+    gcd(gcd(lcm(a, b), lcm(b, c)), lcm(a, c))
+    ==
+    lcm(lcm(gcd(a, b), gcd(b, c)), gcd(a, c))
+
+fn fundamentalTheoremOfArithmetic(a, b) = gcd(a, b) * lcm(a, b) == a * b
+
+let pzn = [-1, 0, 1];
+for(a:pzn) { for(b:pzn) { commutative_lcm(a, b) println } }
+for(a:pzn) { for(b:pzn) { commutative_gcd(a, b) println } }
+for(a:pzn) { for(b:pzn) { for(c:pzn) { associative_lcm(a, b, c) println } } }
+for(a:pzn) { for(b:pzn) { for(c:pzn) { associative_gcd(a, b, c) println } } }
+for(a:pzn) { for(b:pzn) { absorption_lcm(a, b) println } }
+for(a:pzn) { for(b:pzn) { absorption_gcd(a, b) println } }
+for(a:pzn) { idempotence_lcm(a) println }
+for(a:pzn) { idempotence_gcd(a) println }
+for(a:pzn) { for(b:pzn) { for(c:pzn) { distributive_lcm(a, b, c) println } } }
+for(a:pzn) { for(b:pzn) { for(c:pzn) { distributive_lcm(a, b, c) println } } }
+
+let tt = [true,false];
+for(a:pzn) { for(b:pzn) { gcd(a,b) == a || b println } }
+for(a:pzn) { for(b:pzn) { lcm(a,b) == a && b println } }


### PR DESCRIPTION
Here is my improved implementation of lcm and gcd. It should obey the respective lattice laws. The tests should pass posting only true. I was not yet able to run them, because I can only use the REPL, and it doesn't allow me to override basic functions, as it seems.