### PR TITLE
chore: rename hmsl_audible.x to shape_audible.x

### DIFF
--- a/integration-tests/scripts/shape_audible.x
+++ b/integration-tests/scripts/shape_audible.x
@@ -1,11 +1,11 @@
--- hmsl_audible: HMSL-style shapes + hierarchical form, live.
+-- shape_audible: HMSL-inspired shapes + hierarchical form, live.
 -- A form built from shapes with morphological variations; the sel/shuffled
 -- behavior re-rolls at every realize, and three different readings of the
 -- same form are queued back to back on one Player.
 --
 -- Run interactively (Ctrl-C to stop):
 --   ./build/app/tzpl_app --nogui --wait -I lang/modules -I bridge/modules \
---       integration-tests/scripts/hmsl_audible.x
+--       integration-tests/scripts/shape_audible.x
 
 import synthdef.*;
 import common_ugens.*;
@@ -22,14 +22,14 @@ fn sineVoice() S {
     pch nnhz sinosc cb * env * amp
 }
 fn sineSynth() S = voicer(16, sineVoice) sum outlet;
-sineSynth defSynth("hmsl_sine");
+sineSynth defSynth("shape_sine");
 
 engineStart();
 masterGain(0.2);
 setTempo(0, 120.0);
 
 let v = pitchVoice(101);
-voiceBundle(v, "hmsl_sine") go(0);
+voiceBundle(v, "shape_sine") go(0);
 
 randSeed(7);
 

--- a/lang/docs/Music_Libraries.html
+++ b/lang/docs/Music_Libraries.html
@@ -589,7 +589,7 @@ play(patEvents(tune, <span class="hl-num">16.0</span>, <span class="hl-num">2.0<
                 <tr><td><code>integration-tests/scripts/pat_audible.x</code></td><td>Stream patterns live: weighted-random melody + bass via <code>bind</code>/<code>merge</code>.</td></tr>
                 <tr><td><code>integration-tests/scripts/pat_nrt.x</code></td><td>Offline render of a tritave-tuning walk (13 equal divisions of 3/1) via <code>render</code>.</td></tr>
                 <tr><td><code>integration-tests/scripts/media_audible.x</code></td><td>A canon built with <code>$</code>/<code>|</code>/<code>trans</code>/<code>tempo</code> and performed.</td></tr>
-                <tr><td><code>integration-tests/scripts/hmsl_audible.x</code></td><td>Shape morphs + a shuffled hierarchical form, three readings queued on one Player.</td></tr>
+                <tr><td><code>integration-tests/scripts/shape_audible.x</code></td><td>Shape morphs + a shuffled hierarchical form, three readings queued on one Player.</td></tr>
                 <tr><td><code>integration-tests/scripts/spans_audible.x</code></td><td>Euclidean bass, offbeat stab, rotating/reversing melody with a sine-ridden amp.</td></tr>
             </table>
             <a href="#top" class="back-to-top">&uarr; Back to top</a>

--- a/lang/docs/Tzopilotl_Music_Cookbook.html
+++ b/lang/docs/Tzopilotl_Music_Cookbook.html
@@ -1303,7 +1303,7 @@ score with immediate <code>playNote</code>/<code>releaseNote</code> on the silo'
 audio thread.</p>
 <div class="note"><strong>Runnable examples</strong>
 &mdash; <code>integration-tests/scripts/pat_audible.x</code>,
-<code>media_audible.x</code>, <code>hmsl_audible.x</code>,
+<code>media_audible.x</code>, <code>shape_audible.x</code>,
 <code>spans_audible.x</code> (live, one per dialect), and
 <code>pat_nrt.x</code> (offline render in a tritave tuning). Each header has the
 run command. The pure layers are golden-tested in <code>lang/tests/music/</code>.</div>


### PR DESCRIPTION
The integration script is HMSL-inspired, not HMSL itself, so it is renamed after the shape dialect to avoid that confusion.

- `git mv integration-tests/scripts/hmsl_audible.x` → `shape_audible.x`
- Header comment and run instructions updated
- Internal synthdef name `hmsl_sine` → `shape_sine`
- Doc references updated in `lang/docs/Music_Libraries.html` and `lang/docs/Tzopilotl_Music_Cookbook.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)